### PR TITLE
Add ruby3 support

### DIFF
--- a/lib/chef/knife/environmentflip.rb
+++ b/lib/chef/knife/environmentflip.rb
@@ -56,7 +56,7 @@ module KnifeFlip
 
       q_nodes = Chef::Search::Query.new
       node_query = "chef_environment:#{@old_env}"
-      query_nodes = URI.escape(node_query,
+      query_nodes = URI::Parser.new.escape(node_query,
                                Regexp.new("[^#{URI::PATTERN::UNRESERVED}]"))
 
       result_items = []

--- a/lib/chef/knife/roleflip.rb
+++ b/lib/chef/knife/roleflip.rb
@@ -62,7 +62,7 @@ module KnifeFlip
       
       q_nodes = Chef::Search::Query.new
       node_query = "role:#{@role}"
-      query_nodes = URI.escape(node_query,
+      query_nodes = URI::Parser.new.escape(node_query,
                          Regexp.new("[^#{URI::PATTERN::UNRESERVED}]"))
 
       result_items = []

--- a/lib/knife-flip.rb
+++ b/lib/knife-flip.rb
@@ -1,3 +1,3 @@
 module KnifeFlip
-  VERSION = "0.1.6"
+  VERSION = "0.1.7"
 end


### PR DESCRIPTION
`URI.escape` was more-or-less replaced by `URI::Parser.new.escape` in Ruby 3.